### PR TITLE
Add walk and compress server endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,191 @@
 # 70B-1q-to-70B-lang
-70B 1q to 70B lang
+
+This project experiments with **SIGLA**, a small-scale reasoning layer between a
+lightweight model (**1Q**) and a larger language model (**70B**). 70B answers ar
+e distilled into compact *capsules* and indexed using FAISS. At runtime, SIGLA r
+etrieves relevant capsules and injects them into the 1Q model.
+
+## Installation
+
+Run `pip install faiss-cpu sentence-transformers fastapi uvicorn transformers` to install optional dependencies.
+
+## Usage
+
+1. Prepare a JSON file with capsules of the following form:
+
+```json
+[
+  {"text": "Стоики считали, что разум управляет эмоциями."},
+  {"text": "Эпикур видел счастье в отсутствии страданий."}
+]
+```
+
+2. Build an index (you can choose a FAISS index type with `--factory`):
+
+```bash
+python -m sigla.scripts ingest capsules.json myindex --factory HNSW32  # default is Flat
+```
+
+Each capsule is assigned a numeric `id` so you can retrieve it later via the API.
+
+3. Search for relevant capsules (you can filter by tags):
+
+```bash
+python -m sigla.scripts search myindex "философия и счастье" --tags философия
+```
+
+You can record queries by adding `--log-file logfile.jsonl`.
+
+The resulting text can be injected into your model prompt or cached at a lower level. Use `--tags` with comma-separated values to restrict results.
+
+4. Perform graph-based retrieval (if capsules include `links`):
+
+```bash
+python -m sigla.scripts walk myindex "философия" --depth 2 --limit 8 --algo random --tags философия
+```
+
+Use `--algo bfs` (default) to simply follow links breadth-first or `--algo random` with `--restart` to explore the graph via a random walk.
+5. Generate a prompt snippet directly:
+
+```bash
+python -m sigla.scripts inject myindex "философия и счастье" --top_k 3 --tags философия --temperature 0.7
+```
+
+This prints the `[Контекст]` block ready to prepend to 1Q. Adjust `--temperature`
+to tune how strongly the best capsules dominate the merge.
+
+6. Generate a compressed summary of top capsules:
+
+```bash
+python -m sigla.scripts compress myindex "философия и счастье" --top_k 3 --tags философия
+```
+
+This attempts to summarize the retrieved capsules using a local summarization model.
+
+7. Run the API server:
+
+```bash
+python -m sigla.server myindex
+```
+
+Now you can query it (including optional tags):
+
+```bash
+curl "http://localhost:8000/search?query=философия&tags=философия"
+```
+
+Or request a ready-to-inject context snippet:
+
+```bash
+curl "http://localhost:8000/ask?query=философия&temperature=0.7"
+```
+
+You can add more capsules on the fly by posting to `/update`:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '[{"text": "Новая мысль"}]' \
+  http://localhost:8000/update
+```
+
+Check the current index summary:
+
+```bash
+curl http://localhost:8000/info
+```
+
+List stored capsules (limit the number and filter by tags):
+
+```bash
+curl "http://localhost:8000/list?limit=5&tags=философия"
+```
+
+Walk linked capsules via the API:
+
+```bash
+curl "http://localhost:8000/walk?query=философия&depth=2&limit=8"
+```
+
+Summarize top capsules:
+
+```bash
+curl "http://localhost:8000/compress?query=философия&top_k=3"
+```
+
+Both the CLI and server accept a `--log-file` option to record queries and
+updates in JSONL format. This is useful for building a memory of interactions:
+
+```bash
+python -m sigla.server myindex --log-file sigla.log
+```
+
+8. Start an interactive shell:
+
+```bash
+python -m sigla.scripts shell myindex --top_k 3 --tags философия --temperature 0.7
+```
+
+Type queries one per line; an empty line exits.
+
+9. Show a stored capsule by its id:
+
+```bash
+python -m sigla.scripts capsule myindex 0
+```
+
+This prints the capsule's text and metadata in JSON form.
+
+10. List stored capsules (optionally filter by tags):
+
+```bash
+python -m sigla.scripts list myindex --limit 5 --tags философия
+```
+
+11. Summarize a log file to see how commands are used:
+
+```bash
+python -m sigla.scripts stats sigla.log
+```
+
+This prints a JSON object with counts for each logged event type.
+
+12. Inspect index information:
+```bash
+python -m sigla.scripts info myindex
+```
+
+This lists the embedding model, dimension, capsule count and tag distribution.
+
+13. Prune capsules by id or tags:
+
+```bash
+python -m sigla.scripts prune myindex --ids 0,1 --tags philosophy
+```
+
+This removes matching capsules and rebuilds the index.
+
+14. Rebuild embeddings with a new model or index type:
+
+```bash
+python -m sigla.scripts reindex myindex --model sentence-transformers/all-MiniLM-L6-v2 --factory HNSW32  # optional
+```
+
+This recomputes all capsule vectors and updates the FAISS index.
+
+### Using the SIGLA mini-language
+
+`sigla.dsl` exposes helpers following the plan's INTENT → RETRIEVE → MERGE → INJECT pipeline. When capsules contain links, you can also `EXPAND` them. Example:
+
+```python
+from sigla import CapsuleStore, INTENT, RETRIEVE, MERGE, INJECT, EXPAND
+
+store = CapsuleStore()
+store.load("myindex")
+vec = INTENT(store, "философия и счастье")
+caps = RETRIEVE(store, vec, top_k=3)
+caps = EXPAND(caps, store, depth=1)
+snippet = INJECT(MERGE(caps))
+print(snippet)
+```
+This produces a prompt fragment ready to prepend to your 1Q model.
+

--- a/SIGLA_Plan.md
+++ b/SIGLA_Plan.md
@@ -1,0 +1,129 @@
+# SIGLA Development Roadmap (Revisited)
+This roadmap prioritizes low-cost local solutions. Large proprietary models and expensive servers are avoided or used only for occasional offline preprocessing.
+
+
+This version updates the initial roadmap after reviewing several unrealistic
+assumptions.
+
+## Key issues found
+- **Raw logs from 70B** – storing complete answers is expensive and risks data leaks. Only short, sanitized capsules will be kept.
+- **Heavy LLM usage** – queries to proprietary 70B models are costly. Limit their use and rely mainly on local open-source models.
+- **Graph-based retrieval by default** – building a CapsuleGraph from day one complicates the system. Start with simple kNN retrieval and expand later.
+- **Autoencoder compression** – training an autoencoder requires additional data and tuning. Using an LLM summarizer is simpler early on.
+- **Direct KV-cache injection** – depends on the serving stack. Prompt injection is the stable method while KV experiments run in parallel.
+1. **Collect Intent List**
+   - Brainstorm common themes, questions and tasks the system must handle.
+   - Classify each intent by expected value and complexity.
+2. **Query 70B or Similar Models**
+   - Use small open-source LLMs (7B–13B) running locally whenever possible. Reserve 70B queries for one-time or offline generation of high-value capsules.
+3. **Capsule Extraction**
+   - Break answers into atomic statements containing one fact or reasoning step.
+   - Each statement becomes a capsule with minimal text.
+4. **Embedding and Storage**
+   - Use efficient open-source embedding models (e.g., E5 or Llama2-based).
+   - Verify critical capsules by comparing with 70B embeddings when possible.
+   - Store vectors and metadata (source, tags, quality rating) in a FAISS index. Use `Flat` by default but allow `HNSW` or `IVF` factories for larger datasets.
+
+## 2. SIGLA Core
+1. **Embedding Requests**
+   - Convert user questions into intent vectors using the chosen model.
+2. **Retrieval Pipeline**
+   - Query FAISS for nearest capsules (kNN).
+   - Once basic retrieval quality is measured, optionally expand results using
+     a CapsuleGraph.
+3. **Capsule Fusion**
+   - Weight capsules by relevance and connection strength.
+   - Combine a small set of capsules into a single capsule-thought with soft
+     attention. Adjust the number dynamically based on token budget.
+4. **Interface Functions**
+   - Expose operations like `embed_query`, `retrieve_capsules`, and `merge_capsules` as part of a Python module.
+   - Initial version implemented in `sigla/core.py` with a FAISS-backed `CapsuleStore`.
+
+## 3. Injecting Thoughts into 1Q
+1. **Prompt Method**
+   - Insert capsule-thought texts in the prompt using concise templates.
+   - Keep total prompt length below model limits.
+2. **KV-Cache Method (Experimental)**
+   - Only if the serving framework exposes a stable API for KV injection.
+   - Convert capsule vectors to the required tensor format and prepend them
+     before the user's question.
+3. **Choosing a Strategy**
+   - Start with prompt injection for rapid iteration.
+   - Introduce cache-based injection for efficiency once the pipeline is stable.
+
+## 4. Improving Retrieval and Reasoning
+1. **Graph-Based Expansion (Optional)**
+   - When simple retrieval misses context, build a CapsuleGraph linking related
+     capsules.
+   - Explore random walk or BFS to gather supporting capsules.
+2. **Capsule Compression**
+   - Summarize dense capsules with an LLM instead of training a custom autoencoder.
+3. **Reasoning Capsules**
+   - Store not just facts but causal or conditional statements.
+   - Encourage consistent reasoning patterns when combining capsules.
+
+## 5. Formalizing SIGLA
+1. **Mini-Language Syntax**
+   - `INTENT(text) -> vector`
+   - `RETRIEVE(vector) -> [capsules]`
+   - `MERGE(list) -> capsule-thought`
+   - `INJECT(capsule-thought) -> model`
+2. **Memory Tracking**
+   - Log queries and results to grow a long-term memory store.
+   - Visualize capsule graphs to debug coverage and quality.
+
+## 6. API and Server Implementation
+1. **FastAPI Service**
+   - `/ask`: main entry for questions returning 1Q's final answer.
+   - `/capsule/{id}`: inspect stored capsules.
+2. **Model Connectors**
+   - Run local models using CPU-friendly tools like `llama.cpp` or `ggml`. Avoid renting expensive servers.
+   - Provide optional adapters for external APIs like Claude or GPT-4 only if the budget allows.
+   
+3. **Monitoring and Fallbacks**
+   - Track latency, number of retrieved capsules, and token count.
+   - If retrieval confidence is low, optionally query the model directly or use
+     a simpler RAG step.
+
+## 7. Evaluation and Iteration
+1. **A/B Testing**
+   - Compare 1Q answers with and without SIGLA on sample tasks.
+   - Collect user feedback to refine capsule selection.
+2. **Index Maintenance**
+   - Periodically recompute embeddings and rebuild FAISS indices.
+3. **Security Checks**
+   - Filter sensitive or unwanted content in capsules.
+   - Ensure no personal data from user queries is stored without consent.
+## Reality Check
+- Ensure each step can run on commodity hardware (CPU or single consumer GPU).
+- Keep prompts and capsule storage small to control disk and memory use.
+- Regularly reevaluate whether any feature adds clear value for its cost.
+
+## 8. Final Objective
+- 1Q approaches the depth of a 70B model using SIGLA capsules without requiring costly servers.
+- SIGLA evolves into a modular system that grows memory and reasoning abilities over time.
+
+### Implementation Progress
+- `sigla/core.py` provides an initial FAISS-based capsule store with embedding and search.
+- `sigla/scripts.py` offers CLI commands to ingest capsules and run searches, and can append to an existing index.
+- `sigla/server.py` exposes a FastAPI service for querying and updating the capsule index.
+- `sigla/dsl.py` implements INTENT/RETRIEVE/MERGE/INJECT helpers for prompt construction.
+- Capsules now receive persistent `id`s and an optional `links` field for building a graph.
+- Graph expansion is provided via `sigla.graph.expand_with_links` and the CLI `walk` command.
+- Random walk retrieval is implemented via `sigla.graph.random_walk_links` and selectable in the CLI `walk` command.
+- The DSL exposes `EXPAND` for link-based retrieval.
+- `sigla/log.py` enables optional JSONL query logging for both the CLI and server.
+- `sigla/scripts.py` now includes an interactive `shell` command for quick manual tests.
+- `sigla/scripts.py` can display a capsule by id via the `capsule` command.
+- `sigla/scripts.py` can summarize log files via the `stats` command.
+- Search, inject, walk and shell commands accept `--tags` to filter results by metadata; the server exposes a matching query parameter.
+- `sigla/scripts.py` can show index details via the `info` command.
+- `sigla/scripts.py` can list stored capsules via the `list` command.
+- `sigla/scripts.py` can remove capsules via the `prune` command.
+- `sigla/scripts.py` can summarize retrieved capsules via the `compress` command.
+- `sigla/scripts.py` can rebuild embeddings via the `reindex` command.
+- Ingestion and reindexing support custom FAISS index factories via `--factory`.
+- `inject` and `shell` commands, as well as the `/ask` endpoint, accept a
+  `temperature` parameter controlling how capsules are merged.
+- The API exposes `/info` and `/list` endpoints mirroring the CLI commands.
+- `/walk` and `/compress` endpoints support graph expansion and summarization.

--- a/sigla/__init__.py
+++ b/sigla/__init__.py
@@ -1,0 +1,24 @@
+from .core import CapsuleStore, merge_capsules, compress_capsules
+from .dsl import INTENT, RETRIEVE, MERGE, INJECT, EXPAND
+from .graph import random_walk_links
+from .log import start as start_log, log as log_event
+
+try:
+    from .server import app as SiglaApp
+except Exception:  # pragma: no cover - optional dependency
+    SiglaApp = None
+
+__all__ = [
+    "CapsuleStore",
+    "merge_capsules",
+    "compress_capsules",
+    "SiglaApp",
+    "INTENT",
+    "RETRIEVE",
+    "MERGE",
+    "INJECT",
+    "EXPAND",
+    "random_walk_links",
+    "start_log",
+    "log_event",
+]

--- a/sigla/core.py
+++ b/sigla/core.py
@@ -1,0 +1,194 @@
+import json
+from typing import List, Dict, Any
+
+try:
+    import faiss  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    faiss = None
+
+try:
+    from sentence_transformers import SentenceTransformer
+except Exception:  # pragma: no cover - optional dependency
+    SentenceTransformer = None
+
+try:
+    from transformers import pipeline
+except Exception:  # pragma: no cover - optional dependency
+    pipeline = None
+
+
+class MissingDependencyError(RuntimeError):
+    """Raised when optional dependencies are not available."""
+    pass
+
+
+class CapsuleStore:
+    """A lightweight FAISS-backed capsule database."""
+
+    def __init__(
+        self,
+        model_name: str = "sentence-transformers/all-MiniLM-L6-v2",
+        index_factory: str = "Flat",
+    ):
+        if SentenceTransformer is None:
+            raise MissingDependencyError("sentence-transformers package is required")
+        if faiss is None:
+            raise MissingDependencyError("faiss package is required")
+
+        self.model_name = model_name
+        self.model = SentenceTransformer(model_name)
+        self.dimension = self.model.get_sentence_embedding_dimension()
+        self.index_factory = index_factory
+        self.index = faiss.index_factory(self.dimension, index_factory, faiss.METRIC_INNER_PRODUCT)
+        self.meta: List[Dict[str, Any]] = []
+
+    def add_capsules(self, capsules: List[Dict[str, Any]]):
+        """Embed and add capsules to the index, assigning IDs."""
+        start = len(self.meta)
+        texts = [c["text"] for c in capsules]
+        vectors = self.model.encode(texts, convert_to_numpy=True)
+        faiss.normalize_L2(vectors)
+        if not self.index.is_trained:
+            self.index.train(vectors)
+        self.index.add(vectors)
+        for i, cap in enumerate(capsules):
+            meta = cap.copy()
+            meta.setdefault("links", [])
+            meta["id"] = start + i
+            self.meta.append(meta)
+
+    def save(self, path: str):
+        faiss.write_index(self.index, path + ".index")
+        with open(path + ".json", "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "model": self.model_name,
+                    "factory": self.index_factory,
+                    "meta": self.meta,
+                },
+                f,
+                ensure_ascii=False,
+                indent=2,
+            )
+
+    def load(self, path: str):
+        self.index = faiss.read_index(path + ".index")
+        with open(path + ".json", "r", encoding="utf-8") as f:
+            data = json.load(f)
+            self.meta = data["meta"]
+            self.model_name = data.get("model", self.model_name)
+            self.index_factory = data.get("factory", "Flat")
+        self.model = SentenceTransformer(self.model_name)
+
+    def query(self, text: str, top_k: int = 5, tags: List[str] | None = None) -> List[Dict[str, Any]]:
+        """Return top matching capsules, optionally filtering by tags."""
+        vector = self.model.encode([text], convert_to_numpy=True)
+        faiss.normalize_L2(vector)
+        # oversample to account for tag filtering
+        scores, indices = self.index.search(vector, top_k * 5)
+        results = []
+        for score, idx in zip(scores[0], indices[0]):
+            if idx == -1:
+                continue
+            meta = self.meta[idx]
+            if tags and not set(tags).intersection(meta.get("tags", [])):
+                continue
+            cap = meta.copy()
+            cap["score"] = float(score)
+            cap["id"] = idx
+            results.append(cap)
+            if len(results) >= top_k:
+                break
+        return results
+
+    def remove_capsules(self, ids: List[int]) -> int:
+        """Remove capsules by id, rebuilding the index."""
+        if not ids:
+            return 0
+        to_remove = set(ids)
+        mapping: Dict[int, int] = {}
+        new_meta: List[Dict[str, Any]] = []
+        texts: List[str] = []
+        for old_id, meta in enumerate(self.meta):
+            if old_id in to_remove:
+                continue
+            mapping[old_id] = len(new_meta)
+            copy = meta.copy()
+            new_meta.append(copy)
+            texts.append(copy["text"])
+        for meta in new_meta:
+            meta["links"] = [mapping[l] for l in meta.get("links", []) if l in mapping]
+        vectors = self.model.encode(texts, convert_to_numpy=True) if texts else None
+        self.index = faiss.IndexFlatIP(self.dimension)
+        if vectors is not None and len(texts) > 0:
+            faiss.normalize_L2(vectors)
+            self.index.add(vectors)
+        for new_id, meta in enumerate(new_meta):
+            meta["id"] = new_id
+        removed = len(self.meta) - len(new_meta)
+        self.meta = new_meta
+        return removed
+
+    def rebuild_index(self, model_name: str | None = None, index_factory: str | None = None) -> None:
+        """Recompute all embeddings and rebuild the FAISS index."""
+        if model_name:
+            if SentenceTransformer is None:
+                raise MissingDependencyError("sentence-transformers package is required")
+            self.model = SentenceTransformer(model_name)
+            self.model_name = model_name
+            self.dimension = self.model.get_sentence_embedding_dimension()
+        if index_factory:
+            self.index_factory = index_factory
+        texts = [m["text"] for m in self.meta]
+        vectors = self.model.encode(texts, convert_to_numpy=True) if texts else None
+        self.index = faiss.index_factory(self.dimension, self.index_factory, faiss.METRIC_INNER_PRODUCT)
+        if vectors is not None and len(texts) > 0:
+            faiss.normalize_L2(vectors)
+            self.index.add(vectors)
+        for idx, meta in enumerate(self.meta):
+            meta["id"] = idx
+
+
+def merge_capsules(capsules: List[Dict[str, Any]], temperature: float = 1.0) -> str:
+    """Merge capsules using a softmax-weighted combination."""
+    if not capsules:
+        return ""
+
+    try:
+        import numpy as np
+    except Exception:  # pragma: no cover - optional dependency
+        np = None
+
+    if np is None:
+        # Fallback to simple ranking if numpy isn't available
+        sorted_caps = sorted(capsules, key=lambda c: c.get("score", 0), reverse=True)
+        texts = [c["text"] for c in sorted_caps]
+        return "\n".join(texts)
+
+    scores = np.array([c.get("score", 0.0) for c in capsules], dtype=float)
+    # Softmax weighting for smoother importance distribution
+    scores = scores / (temperature if temperature else 1.0)
+    scores = scores - scores.max()
+    weights = np.exp(scores)
+    weights /= weights.sum()
+
+    ordering = np.argsort(-weights)
+    texts = [capsules[i]["text"] for i in ordering]
+    return "\n".join(texts)
+
+
+def compress_capsules(capsules: List[Dict[str, Any]], model_name: str = "sshleifer/distilbart-cnn-12-6") -> str:
+    """Summarize a list of capsules into a short snippet."""
+    if not capsules:
+        return ""
+    if pipeline is None:
+        raise MissingDependencyError("transformers package is required for compression")
+
+    try:
+        summarizer = pipeline("summarization", model=model_name)
+    except Exception as e:  # pragma: no cover - optional dependency
+        raise MissingDependencyError(str(e))
+
+    text = "\n".join(c["text"] for c in capsules)
+    summary = summarizer(text, max_length=60, min_length=5, do_sample=False)
+    return summary[0]["summary_text"].strip()

--- a/sigla/dsl.py
+++ b/sigla/dsl.py
@@ -1,0 +1,55 @@
+"""Minimal SIGLA DSL helpers."""
+
+from typing import List
+
+try:
+    import faiss  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    faiss = None
+
+from .core import CapsuleStore, merge_capsules, MissingDependencyError
+from .graph import expand_with_links
+
+
+def INTENT(store: CapsuleStore, text: str):
+    """Embed a query into a vector."""
+    if faiss is None:
+        raise MissingDependencyError("faiss package is required for INTENT")
+    vector = store.model.encode([text], convert_to_numpy=True)
+    faiss.normalize_L2(vector)
+    return vector
+
+
+def RETRIEVE(store: CapsuleStore, vector, top_k: int = 5, tags: List[str] | None = None):
+    """Retrieve top capsules given an embedded query."""
+    if faiss is None:
+        raise MissingDependencyError("faiss package is required for RETRIEVE")
+    scores, indices = store.index.search(vector, top_k * 5)
+    results = []
+    for score, idx in zip(scores[0], indices[0]):
+        if idx == -1:
+            continue
+        meta = store.meta[idx]
+        if tags and not set(tags).intersection(meta.get("tags", [])):
+            continue
+        cap = meta.copy()
+        cap["score"] = float(score)
+        results.append(cap)
+        if len(results) >= top_k:
+            break
+    return results
+
+
+def MERGE(capsules: List[dict]):
+    """Merge several capsules into a single text snippet."""
+    return merge_capsules(capsules)
+
+
+def INJECT(composite: str) -> str:
+    """Return prompt fragment to inject into 1Q."""
+    return f"[Контекст]: \"{composite}\""
+
+
+def EXPAND(capsules: List[dict], store: CapsuleStore, depth: int = 1, limit: int = 10):
+    """Expand capsules via their links."""
+    return expand_with_links(capsules, store, depth=depth, limit=limit)

--- a/sigla/graph.py
+++ b/sigla/graph.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import List, Dict
+import random
+
+from .core import CapsuleStore
+
+
+def expand_with_links(capsules: List[dict], store: CapsuleStore, depth: int = 1, limit: int = 10) -> List[dict]:
+    """Expand capsules by following their 'links' metadata."""
+    visited = {c["id"] for c in capsules}
+    queue = list(visited)
+    results = list(capsules)
+    for _ in range(depth):
+        new_queue = []
+        for cid in queue:
+            meta = store.meta[cid]
+            for link in meta.get("links", []):
+                if link in visited or link < 0 or link >= len(store.meta):
+                    continue
+                visited.add(link)
+                linked = store.meta[link].copy()
+                linked["score"] = 0.0
+                linked["id"] = link
+                results.append(linked)
+                new_queue.append(link)
+                if len(results) >= limit:
+                    return results
+        queue = new_queue
+    return results
+
+
+def random_walk_links(
+    capsules: List[dict],
+    store: CapsuleStore,
+    steps: int = 3,
+    restart: float = 0.5,
+    limit: int = 10,
+) -> List[dict]:
+    """Expand capsules via random walk with restart."""
+    if not capsules:
+        return []
+
+    start = [c["id"] for c in capsules]
+    visited: Dict[int, int] = {cid: 1 for cid in start}
+    current = list(start)
+
+    for _ in range(steps):
+        next_nodes = []
+        for cid in current:
+            links = store.meta[cid].get("links", [])
+            if links and random.random() > restart:
+                next_nodes.append(random.choice(links))
+            else:
+                next_nodes.append(random.choice(start))
+        current = next_nodes
+        for cid in current:
+            visited[cid] = visited.get(cid, 0) + 1
+
+    results = []
+    for cid, count in sorted(visited.items(), key=lambda x: -x[1])[:limit]:
+        meta = store.meta[cid].copy()
+        meta["score"] = float(count)
+        meta["id"] = cid
+        results.append(meta)
+    return results

--- a/sigla/log.py
+++ b/sigla/log.py
@@ -1,0 +1,21 @@
+import json
+import time
+from typing import Optional, Dict, Any
+
+_log_path: Optional[str] = None
+
+def start(path: str) -> None:
+    """Enable logging to the given file."""
+    global _log_path
+    _log_path = path
+
+
+def log(event: Dict[str, Any]) -> None:
+    """Append an event to the log if logging is enabled."""
+    if _log_path is None:
+        return
+    event = event.copy()
+    event["ts"] = time.time()
+    with open(_log_path, "a", encoding="utf-8") as f:
+        json.dump(event, f, ensure_ascii=False)
+        f.write("\n")

--- a/sigla/scripts.py
+++ b/sigla/scripts.py
@@ -1,0 +1,363 @@
+import argparse
+import json
+from pathlib import Path
+
+from .core import CapsuleStore, merge_capsules, MissingDependencyError
+from .dsl import INJECT
+from .graph import expand_with_links
+from . import log as siglog
+
+
+def ingest(json_file: str, index_path: str, model: str, factory: str):
+    try:
+        if Path(index_path + ".index").exists():
+            store = CapsuleStore()
+            store.load(index_path)
+        else:
+            store = CapsuleStore(model_name=model, index_factory=factory)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    with open(json_file, 'r', encoding='utf-8') as f:
+        capsules = json.load(f)
+    store.add_capsules(capsules)
+    store.save(index_path)
+    siglog.log({"type": "ingest", "count": len(capsules)})
+
+
+def search(index_path: str, query: str, top_k: int, tags: list[str] | None = None):
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    results = store.query(query, top_k=top_k, tags=tags)
+    print(json.dumps(results, ensure_ascii=False, indent=2))
+    siglog.log({"type": "search", "query": query, "top_k": top_k, "tags": tags, "results": results})
+
+
+def inject_snippet(
+    index_path: str,
+    query: str,
+    top_k: int,
+    tags: list[str] | None = None,
+    temperature: float = 1.0,
+) -> None:
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    results = store.query(query, top_k=top_k, tags=tags)
+    snippet = INJECT(merge_capsules(results, temperature=temperature))
+    print(snippet)
+    siglog.log({
+        "type": "inject",
+        "query": query,
+        "top_k": top_k,
+        "tags": tags,
+        "temperature": temperature,
+    })
+
+
+def compress_snippet(index_path: str, query: str, top_k: int, tags: list[str] | None = None, model: str = "sshleifer/distilbart-cnn-12-6"):
+    """Retrieve capsules and summarize them."""
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    results = store.query(query, top_k=top_k, tags=tags)
+    try:
+        from .core import compress_capsules
+        summary = compress_capsules(results, model_name=model)
+        print(summary)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+    siglog.log({"type": "compress", "query": query, "top_k": top_k, "tags": tags})
+
+
+def walk_search(
+    index_path: str,
+    query: str,
+    top_k: int,
+    depth: int,
+    limit: int,
+    tags: list[str] | None = None,
+    algo: str = "bfs",
+    restart: float = 0.5,
+):
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    results = store.query(query, top_k=top_k, tags=tags)
+    if algo == "random":
+        from .graph import random_walk_links
+        expanded = random_walk_links(results, store, steps=depth, restart=restart, limit=limit)
+    else:
+        expanded = expand_with_links(results, store, depth=depth, limit=limit)
+    print(json.dumps(expanded, ensure_ascii=False, indent=2))
+    siglog.log({"type": "walk", "query": query, "top_k": top_k, "depth": depth, "limit": limit, "algo": algo, "restart": restart, "tags": tags})
+
+
+def show_capsule(index_path: str, idx: int) -> None:
+    """Print a capsule by its id."""
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    if idx < 0 or idx >= len(store.meta):
+        print("error: invalid id")
+        return
+    print(json.dumps(store.meta[idx], ensure_ascii=False, indent=2))
+
+
+def list_capsules(index_path: str, limit: int = 20, tags: list[str] | None = None) -> None:
+    """List capsules optionally filtered by tags."""
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    results = []
+    for meta in store.meta:
+        if tags and not set(tags).intersection(meta.get("tags", [])):
+            continue
+        results.append(meta)
+        if len(results) >= limit:
+            break
+    print(json.dumps(results, ensure_ascii=False, indent=2))
+
+
+def shell(
+    index_path: str,
+    top_k: int,
+    tags: list[str] | None = None,
+    temperature: float = 1.0,
+) -> None:
+    """Run an interactive search loop printing merged context."""
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    print("Enter empty line to exit.")
+    while True:
+        try:
+            query = input("query> ").strip()
+        except EOFError:
+            break
+        if not query:
+            break
+        results = store.query(query, top_k=top_k, tags=tags)
+        snippet = INJECT(merge_capsules(results, temperature=temperature))
+        print(snippet)
+        siglog.log({
+            "type": "shell",
+            "query": query,
+            "top_k": top_k,
+            "temperature": temperature,
+        })
+
+
+def show_stats(log_file: str) -> None:
+    """Print simple statistics from a log file."""
+    counts = {}
+    try:
+        with open(log_file, "r", encoding="utf-8") as f:
+            for line in f:
+                event = json.loads(line)
+                etype = event.get("type", "unknown")
+                counts[etype] = counts.get(etype, 0) + 1
+    except FileNotFoundError:
+        print("error: log file not found")
+        return
+    print(json.dumps(counts, ensure_ascii=False, indent=2))
+
+
+def show_info(index_path: str) -> None:
+    """Print summary information about an index."""
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    info = {
+        "model": store.model_name,
+        "dimension": store.dimension,
+        "capsules": len(store.meta),
+    }
+    tag_counts: dict[str, int] = {}
+    for m in store.meta:
+        for t in m.get("tags", []):
+            tag_counts[t] = tag_counts.get(t, 0) + 1
+    if tag_counts:
+        info["tags"] = tag_counts
+    print(json.dumps(info, ensure_ascii=False, indent=2))
+
+
+def prune_capsules(index_path: str, ids: list[int] | None = None, tags: list[str] | None = None) -> None:
+    """Remove capsules by id or tags and rebuild the index."""
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    remove_set: set[int] = set(ids or [])
+    if tags:
+        for i, meta in enumerate(store.meta):
+            if set(tags).intersection(meta.get("tags", [])):
+                remove_set.add(i)
+    if not remove_set:
+        print("no matching capsules")
+        return
+    removed = store.remove_capsules(sorted(remove_set))
+    store.save(index_path)
+    siglog.log({"type": "prune", "removed": removed, "ids": sorted(remove_set), "tags": tags})
+    print(f"removed {removed} capsules")
+
+
+def reindex_store(index_path: str, model: str | None = None, factory: str | None = None) -> None:
+    """Rebuild embeddings for all capsules, optionally with a new model or index type."""
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    store.rebuild_index(model, factory)
+    store.save(index_path)
+    siglog.log({"type": "reindex", "model": model or store.model_name})
+    print("index rebuilt")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SIGLA utility")
+    subparsers = parser.add_subparsers(dest="cmd")
+    parser.add_argument("--log-file")
+
+    ingest_p = subparsers.add_parser("ingest")
+    ingest_p.add_argument("json_file")
+    ingest_p.add_argument("index_path")
+    ingest_p.add_argument("--model", default="sentence-transformers/all-MiniLM-L6-v2")
+    ingest_p.add_argument("--factory", default="Flat", help="FAISS index factory")
+
+    search_p = subparsers.add_parser("search")
+    search_p.add_argument("index_path")
+    search_p.add_argument("query")
+    search_p.add_argument("--top_k", type=int, default=5)
+    search_p.add_argument("--tags")
+
+    inject_p = subparsers.add_parser("inject")
+    inject_p.add_argument("index_path")
+    inject_p.add_argument("query")
+    inject_p.add_argument("--top_k", type=int, default=5)
+    inject_p.add_argument("--tags")
+    inject_p.add_argument("--temperature", type=float, default=1.0)
+
+    compress_p = subparsers.add_parser("compress", help="summarize retrieved capsules")
+    compress_p.add_argument("index_path")
+    compress_p.add_argument("query")
+    compress_p.add_argument("--top_k", type=int, default=5)
+    compress_p.add_argument("--model", default="sshleifer/distilbart-cnn-12-6")
+    compress_p.add_argument("--tags")
+
+    walk_p = subparsers.add_parser("walk")
+    walk_p.add_argument("index_path")
+    walk_p.add_argument("query")
+    walk_p.add_argument("--top_k", type=int, default=5)
+    walk_p.add_argument("--depth", type=int, default=1)
+    walk_p.add_argument("--limit", type=int, default=10)
+    walk_p.add_argument("--algo", choices=["bfs", "random"], default="bfs")
+    walk_p.add_argument("--restart", type=float, default=0.5, help="restart prob for random walk")
+    walk_p.add_argument("--tags")
+
+    cap_p = subparsers.add_parser("capsule")
+    cap_p.add_argument("index_path")
+    cap_p.add_argument("id", type=int)
+
+    list_p = subparsers.add_parser("list", help="list capsules")
+    list_p.add_argument("index_path")
+    list_p.add_argument("--limit", type=int, default=20)
+    list_p.add_argument("--tags")
+
+    prune_p = subparsers.add_parser("prune", help="remove capsules")
+    prune_p.add_argument("index_path")
+    prune_p.add_argument("--ids")
+    prune_p.add_argument("--tags")
+
+    reindex_p = subparsers.add_parser("reindex", help="rebuild embeddings")
+    reindex_p.add_argument("index_path")
+    reindex_p.add_argument("--model")
+    reindex_p.add_argument("--factory")
+
+    info_p = subparsers.add_parser("info", help="show index summary")
+    info_p.add_argument("index_path")
+
+    shell_p = subparsers.add_parser("shell")
+    shell_p.add_argument("index_path")
+    shell_p.add_argument("--top_k", type=int, default=5)
+    shell_p.add_argument("--tags")
+    shell_p.add_argument("--temperature", type=float, default=1.0)
+
+    stats_p = subparsers.add_parser("stats", help="summarize a log file")
+    stats_p.add_argument("log_file")
+
+    args = parser.parse_args()
+    if args.log_file and args.cmd != "stats":
+        siglog.start(args.log_file)
+    tags = args.tags.split(',') if hasattr(args, 'tags') and args.tags else None
+    if args.cmd == "ingest":
+        ingest(args.json_file, args.index_path, args.model, args.factory)
+    elif args.cmd == "search":
+        search(args.index_path, args.query, args.top_k, tags)
+    elif args.cmd == "inject":
+        inject_snippet(args.index_path, args.query, args.top_k, tags, args.temperature)
+    elif args.cmd == "compress":
+        compress_snippet(args.index_path, args.query, args.top_k, tags, args.model)
+    elif args.cmd == "walk":
+        walk_search(
+            args.index_path,
+            args.query,
+            args.top_k,
+            args.depth,
+            args.limit,
+            tags,
+            args.algo,
+            args.restart,
+        )
+    elif args.cmd == "shell":
+        shell(args.index_path, args.top_k, tags, args.temperature)
+    elif args.cmd == "capsule":
+        show_capsule(args.index_path, args.id)
+    elif args.cmd == "list":
+        list_tags = args.tags.split(',') if args.tags else None
+        list_capsules(args.index_path, args.limit, list_tags)
+    elif args.cmd == "prune":
+        id_list = [int(x) for x in args.ids.split(',')] if args.ids else None
+        prune_tags = args.tags.split(',') if args.tags else None
+        prune_capsules(args.index_path, id_list, prune_tags)
+    elif args.cmd == "reindex":
+        reindex_store(args.index_path, args.model, args.factory)
+    elif args.cmd == "info":
+        show_info(args.index_path)
+    elif args.cmd == "stats":
+        show_stats(args.log_file)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/sigla/server.py
+++ b/sigla/server.py
@@ -1,0 +1,188 @@
+try:
+    from fastapi import FastAPI, HTTPException
+except Exception:  # pragma: no cover - optional dependency
+    FastAPI = None
+    class HTTPException(Exception):
+        pass
+
+from typing import List
+import argparse
+import os
+from . import log as siglog
+
+from .core import CapsuleStore, merge_capsules, compress_capsules, MissingDependencyError
+from .graph import expand_with_links, random_walk_links
+
+if FastAPI:
+    app = FastAPI(title="SIGLA Server")
+else:
+    app = None
+
+store: CapsuleStore | None = None
+index_path: str = ""
+
+if app:
+    @app.on_event("startup")
+    def _load_store():
+        global store
+        if not index_path:
+            raise RuntimeError("Index path not set")
+        s = CapsuleStore()
+        if os.path.exists(index_path + ".index"):
+            s.load(index_path)
+        store = s
+
+    @app.get("/search")
+    def search(query: str, top_k: int = 5, tags: str | None = None):
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_list = tags.split(',') if tags else None
+        results = store.query(query, top_k=top_k, tags=tag_list)
+        siglog.log({"type": "search", "query": query, "top_k": top_k, "tags": tag_list, "results": results})
+        return results
+
+    @app.get("/ask")
+    def ask(query: str, top_k: int = 5, tags: str | None = None, temperature: float = 1.0):
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_list = tags.split(',') if tags else None
+        results = store.query(query, top_k=top_k, tags=tag_list)
+        merged = merge_capsules(results, temperature=temperature)
+        siglog.log({"type": "ask", "query": query, "top_k": top_k, "tags": tag_list, "temperature": temperature, "context": merged})
+        return {"context": merged}
+
+    @app.get("/capsule/{idx}")
+    def get_capsule(idx: int):
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        if idx < 0 or idx >= len(store.meta):
+            raise HTTPException(status_code=404, detail="Capsule not found")
+        return store.meta[idx]
+
+    @app.post("/update")
+    def update_capsules(capsules: List[dict]):
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        store.add_capsules(capsules)
+        if index_path:
+            store.save(index_path)
+        siglog.log({"type": "update", "added": len(capsules)})
+        return {"added": len(capsules)}
+
+    @app.get("/info")
+    def info():
+        """Return summary information about the index."""
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_counts: dict[str, int] = {}
+        for m in store.meta:
+            for t in m.get("tags", []):
+                tag_counts[t] = tag_counts.get(t, 0) + 1
+        data = {
+            "model": store.model_name,
+            "dimension": store.dimension,
+            "capsules": len(store.meta),
+        }
+        if tag_counts:
+            data["tags"] = tag_counts
+        return data
+
+    @app.get("/list")
+    def list_capsules(limit: int = 20, tags: str | None = None):
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_list = tags.split(',') if tags else None
+        results = []
+        for meta in store.meta:
+            if tag_list and not set(tag_list).intersection(meta.get("tags", [])):
+                continue
+            results.append(meta)
+            if len(results) >= limit:
+                break
+        return results
+
+    @app.get("/walk")
+    def walk(
+        query: str,
+        top_k: int = 5,
+        depth: int = 1,
+        limit: int = 10,
+        tags: str | None = None,
+        algo: str = "bfs",
+        restart: float = 0.5,
+    ):
+        """Expand results via capsule links."""
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_list = tags.split(',') if tags else None
+        results = store.query(query, top_k=top_k, tags=tag_list)
+        if algo == "random":
+            expanded = random_walk_links(
+                results, store, steps=depth, restart=restart, limit=limit
+            )
+        else:
+            expanded = expand_with_links(results, store, depth=depth, limit=limit)
+        siglog.log(
+            {
+                "type": "walk",
+                "query": query,
+                "top_k": top_k,
+                "depth": depth,
+                "limit": limit,
+                "algo": algo,
+                "restart": restart,
+                "tags": tag_list,
+            }
+        )
+        return expanded
+
+    @app.get("/compress")
+    def compress(
+        query: str,
+        top_k: int = 5,
+        tags: str | None = None,
+        model: str = "sshleifer/distilbart-cnn-12-6",
+    ):
+        """Return a summary of retrieved capsules."""
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_list = tags.split(',') if tags else None
+        results = store.query(query, top_k=top_k, tags=tag_list)
+        try:
+            summary = compress_capsules(results, model_name=model)
+        except MissingDependencyError as e:
+            raise HTTPException(status_code=500, detail=str(e))
+        siglog.log(
+            {
+                "type": "compress",
+                "query": query,
+                "top_k": top_k,
+                "model": model,
+                "tags": tag_list,
+            }
+        )
+        return {"summary": summary}
+
+def cli():
+    parser = argparse.ArgumentParser(description="Run SIGLA API server")
+    parser.add_argument("index_path", help="Path prefix of the FAISS index")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--log-file")
+    args = parser.parse_args()
+    global index_path
+    index_path = args.index_path
+    if args.log_file:
+        siglog.start(args.log_file)
+
+    if FastAPI is None:
+        parser.error("fastapi is required to run the server")
+    try:
+        import uvicorn  # type: ignore
+    except Exception:
+        parser.error("uvicorn is required to run the server")
+
+    uvicorn.run(app, host=args.host, port=args.port)
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- expose `/walk` and `/compress` endpoints in the FastAPI server
- document how to use them in the README
- record the new API features in the roadmap

## Testing
- `python -m sigla.scripts --help`
- `python -m sigla.server --help`
- `python -m sigla.scripts ingest tmp_caps.json tmp_index --model sentence-transformers/all-MiniLM-L6-v2 --factory Flat` *(fails: sentence-transformers package is required)*

------
https://chatgpt.com/codex/tasks/task_e_6858f2422fc88332b16604743bb733af