### PR TITLE
Add embed vector command and endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,306 @@
 # 70B-1q-to-70B-lang
-70B 1q to 70B lang
+
+This project experiments with **SIGLA**, a small-scale reasoning layer between a
+lightweight model (**1Q**) and a larger language model (**70B**). 70B answers ar
+e distilled into compact *capsules* and indexed using FAISS. At runtime, SIGLA r
+etrieves relevant capsules and injects them into the 1Q model.
+
+## Installation
+
+Run `pip install faiss-cpu sentence-transformers fastapi uvicorn transformers` to install optional dependencies.
+
+If you see an error about `faiss` being missing, install it explicitly:
+
+```bash
+pip install faiss-cpu
+# or, for GPUs
+pip install faiss-gpu
+```
+On systems where pip wheels are unavailable (for example on macOS), install via conda:
+
+```bash
+conda install -c conda-forge faiss-cpu
+```
+
+The first run also downloads the sentence-transformer model from the internet,
+so ensure the machine has network access and that your cache directory is writable.
+
+Commands that simply read the index (e.g. `list` or `info`) work without the
+embedding model because `CapsuleStore` loads it lazily when needed.
+If `sentence-transformers` isn't installed, SIGLA falls back to a simple
+hash-based embedder so you can experiment without heavy dependencies.
+You can also force this lightweight mode by passing `--model hash` when
+ingesting or reindexing so no model download is required.
+
+### Reality Check
+
+SIGLA is designed to run on modest hardware. While the concept originates from
+70B-scale models, day-to-day retrieval uses compact open-source embeddings and a
+lightweight FAISS index. Heavy LLMs are only needed offline when producing the
+initial knowledge base. You can run the CLI and server entirely on a CPU, or a
+single consumer GPU, without renting expensive infrastructure.
+
+For more background and long-term goals see `SIGLA_Plan.md`.
+
+## Usage
+
+1. Convert raw text from a larger model into capsules:
+
+```bash
+python -m sigla.scripts capsulate answers.txt caps.json --tags философия --source Claude
+# or use '-' to read from stdin or write to stdout
+cat answers.txt | python -m sigla.scripts capsulate - - > caps.json
+```
+
+This splits the text into sentences, sanitizes them and saves JSON capsules.
+
+2. Example capsule file:
+
+```json
+[
+  {"text": "Стоики считали, что разум управляет эмоциями."},
+  {"text": "Эпикур видел счастье в отсутствии страданий."}
+]
+```
+
+3. Build an index (you can tag capsules and choose a FAISS index type):
+
+```bash
+python -m sigla.scripts ingest capsules.json myindex --factory HNSW32 --link 3 --tags philosophy --source Claude
+# add --no-dedup to keep duplicate texts
+# default factory is Flat
+# pass --model hash if you don't have sentence-transformers installed
+```
+Sensitive tokens like email addresses or long numeric IDs are automatically
+redacted during ingestion.
+Duplicate sentences are skipped unless you pass `--no-dedup`.
+
+Each capsule is assigned a numeric `id` so you can retrieve it later via the API.
+
+4. Append new capsules to the same index later:
+
+```bash
+python -m sigla.scripts update more_caps.json myindex --link 3 --tags philosophy --source Claude
+# add --no-dedup to allow identical capsules
+```
+
+Use this to grow the knowledge base without rebuilding the index.
+
+5. Search for relevant capsules (you can filter by tags):
+
+```bash
+python -m sigla.scripts search myindex "философия и счастье" --tags философия
+```
+
+You can record queries by adding `--log-file logfile.jsonl`.
+
+The resulting text can be injected into your model prompt or cached at a lower level. Use `--tags` with comma-separated values to restrict results.
+
+6. Perform graph-based retrieval (if capsules include `links`):
+
+```bash
+python -m sigla.scripts walk myindex "философия" --depth 2 --limit 8 --algo random --tags философия
+```
+
+Use `--algo bfs` (default) to simply follow links breadth-first or `--algo random` with `--restart` to explore the graph via a random walk.
+7. Generate a prompt snippet directly:
+
+```bash
+python -m sigla.scripts inject myindex "философия и счастье" --top_k 3 --tags философия --temperature 0.7
+```
+
+This prints the `[Контекст]` block ready to prepend to 1Q. Adjust `--temperature`
+to tune how strongly the best capsules dominate the merge.
+
+8. Generate a compressed summary of top capsules:
+
+```bash
+python -m sigla.scripts compress myindex "философия и счастье" --top_k 3 --tags философия
+```
+
+This attempts to summarize the retrieved capsules using a local summarization model.
+
+9. Run the API server:
+
+```bash
+python -m sigla.server myindex
+```
+
+Now you can query it (including optional tags):
+
+```bash
+curl "http://localhost:8000/search?query=философия&tags=философия"
+```
+
+Or request a ready-to-inject context snippet:
+
+```bash
+curl "http://localhost:8000/ask?query=философия&temperature=0.7"
+```
+
+You can add more capsules on the fly by posting to `/update` (optionally auto-linking them with `link_neighbors`):
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '[{"text": "Новая мысль"}]' \
+  "http://localhost:8000/update?link_neighbors=3"
+```
+
+Check the current index summary:
+
+```bash
+curl http://localhost:8000/info
+```
+
+List stored capsules (limit the number and filter by tags):
+
+```bash
+curl "http://localhost:8000/list?limit=5&tags=философия"
+```
+
+Export capsules via the API:
+
+```bash
+curl "http://localhost:8000/dump?limit=10&tags=философия" > dump.json
+```
+
+Walk linked capsules via the API:
+
+```bash
+curl "http://localhost:8000/walk?query=философия&depth=2&limit=8"
+```
+
+Get a Graphviz representation of capsule links:
+
+```bash
+curl "http://localhost:8000/graph?limit=100" > graph.dot
+```
+
+Summarize top capsules:
+
+```bash
+curl "http://localhost:8000/compress?query=философия&top_k=3"
+```
+
+Remove capsules via the API:
+
+```bash
+curl -X POST "http://localhost:8000/prune?ids=0,1&tags=философия"
+```
+
+Rebuild embeddings through the server:
+
+```bash
+curl -X POST "http://localhost:8000/reindex?model=sentence-transformers/all-MiniLM-L6-v2&factory=HNSW32"
+```
+
+Request an embedding vector for arbitrary text:
+
+```bash
+curl "http://localhost:8000/embed?text=пример"
+```
+
+Both the CLI and server accept a `--log-file` option to record queries and
+updates in JSONL format. This is useful for building a memory of interactions:
+
+```bash
+python -m sigla.server myindex --log-file sigla.log
+```
+
+10. Start an interactive shell:
+
+```bash
+python -m sigla.scripts shell myindex --top_k 3 --tags философия --temperature 0.7
+```
+
+Type queries one per line; an empty line exits.
+
+11. Show a stored capsule by its id:
+
+```bash
+python -m sigla.scripts capsule myindex 0
+```
+
+This prints the capsule's text and metadata in JSON form.
+
+12. List stored capsules (optionally filter by tags):
+
+```bash
+python -m sigla.scripts list myindex --limit 5 --tags философия
+```
+
+13. Export capsules to a JSON file:
+
+```bash
+python -m sigla.scripts export myindex dump.json --tags философия
+```
+
+This saves matching capsules in `dump.json`.
+
+14. Export the capsule graph to Graphviz DOT:
+
+```bash
+python -m sigla.scripts graph myindex graph.dot --limit 100
+```
+
+This writes `graph.dot` describing capsules and their links.
+
+15. Summarize a log file to see how commands are used:
+
+```bash
+python -m sigla.scripts stats sigla.log
+```
+
+This prints a JSON object with counts for each logged event type.
+
+16. Inspect index information:
+```bash
+python -m sigla.scripts info myindex
+```
+
+This lists the embedding model, dimension, capsule count and tag distribution.
+
+17. Prune capsules by id or tags:
+
+```bash
+python -m sigla.scripts prune myindex --ids 0,1 --tags philosophy
+```
+
+This removes matching capsules and rebuilds the index.
+
+18. Rebuild embeddings with a new model or index type:
+
+```bash
+python -m sigla.scripts reindex myindex --model sentence-transformers/all-MiniLM-L6-v2 --factory HNSW32  # optional
+```
+
+This recomputes all capsule vectors and updates the FAISS index.
+
+19. Get an embedding vector for any text:
+
+```bash
+python -m sigla.scripts embed "пример текста" --model sentence-transformers/all-MiniLM-L6-v2
+```
+
+This prints the vector as JSON so you can reuse it elsewhere.
+
+### Using the SIGLA mini-language
+
+`sigla.dsl` exposes helpers following the plan's INTENT → RETRIEVE → MERGE → INJECT pipeline. When capsules contain links, you can also `EXPAND` them. Example:
+
+```python
+from sigla import CapsuleStore, INTENT, RETRIEVE, MERGE, INJECT, EXPAND
+
+# "lazy=True" delays loading the embedding model until needed
+store = CapsuleStore(lazy=True)
+store.load("myindex")
+vec = INTENT(store, "философия и счастье")
+caps = RETRIEVE(store, vec, top_k=3)
+caps = EXPAND(caps, store, depth=1)
+snippet = INJECT(MERGE(caps))
+print(snippet)
+```
+This produces a prompt fragment ready to prepend to your 1Q model. You can also
+call `store.embed_query("text")` directly if you only need the normalized
+vector.
+

--- a/SIGLA_Plan.md
+++ b/SIGLA_Plan.md
@@ -1,0 +1,145 @@
+# SIGLA Development Roadmap (Revisited)
+This roadmap prioritizes low-cost local solutions. Large proprietary models and expensive servers are avoided or used only for occasional offline preprocessing.
+
+
+This version updates the initial roadmap after reviewing several unrealistic
+assumptions.
+
+## Key issues found
+- **Raw logs from 70B** – storing complete answers is expensive and risks data leaks. Only short, sanitized capsules will be kept.
+- **Heavy LLM usage** – queries to proprietary 70B models are costly. Limit their use and rely mainly on local open-source models.
+- **Graph-based retrieval by default** – building a CapsuleGraph from day one complicates the system. Start with simple kNN retrieval and expand later.
+- **Autoencoder compression** – training an autoencoder requires additional data and tuning. Using an LLM summarizer is simpler early on.
+- **Direct KV-cache injection** – depends on the serving stack. Prompt injection is the stable method while KV experiments run in parallel.
+1. **Collect Intent List**
+   - Brainstorm common themes, questions and tasks the system must handle.
+   - Classify each intent by expected value and complexity.
+2. **Query 70B or Similar Models**
+   - Use small open-source LLMs (7B–13B) running locally whenever possible. Reserve 70B queries for one-time or offline generation of high-value capsules.
+3. **Capsule Extraction**
+   - Break answers into atomic statements containing one fact or reasoning step.
+   - Each statement becomes a capsule with minimal text.
+4. **Embedding and Storage**
+   - Use efficient open-source embedding models (e.g., E5 or Llama2-based).
+   - Verify critical capsules by comparing with 70B embeddings when possible.
+   - Store vectors and metadata (source, tags, quality rating) in a FAISS index. Use `Flat` by default but allow `HNSW` or `IVF` factories for larger datasets.
+
+## 2. SIGLA Core
+1. **Embedding Requests**
+   - Convert user questions into intent vectors using the chosen model.
+2. **Retrieval Pipeline**
+   - Query FAISS for nearest capsules (kNN).
+   - Once basic retrieval quality is measured, optionally expand results using
+     a CapsuleGraph.
+3. **Capsule Fusion**
+   - Weight capsules by relevance and connection strength.
+   - Combine a small set of capsules into a single capsule-thought with soft
+     attention. Adjust the number dynamically based on token budget.
+4. **Interface Functions**
+   - Expose operations like `embed_query`, `retrieve_capsules`, and `merge_capsules` as part of a Python module.
+   - Initial version implemented in `sigla/core.py` with a FAISS-backed `CapsuleStore`.
+
+## 3. Injecting Thoughts into 1Q
+1. **Prompt Method**
+   - Insert capsule-thought texts in the prompt using concise templates.
+   - Keep total prompt length below model limits.
+2. **KV-Cache Method (Experimental)**
+   - Only if the serving framework exposes a stable API for KV injection.
+   - Convert capsule vectors to the required tensor format and prepend them
+     before the user's question.
+3. **Choosing a Strategy**
+   - Start with prompt injection for rapid iteration.
+   - Introduce cache-based injection for efficiency once the pipeline is stable.
+
+## 4. Improving Retrieval and Reasoning
+1. **Graph-Based Expansion (Optional)**
+   - When simple retrieval misses context, build a CapsuleGraph linking related
+     capsules.
+   - Explore random walk or BFS to gather supporting capsules.
+2. **Capsule Compression**
+   - Summarize dense capsules with an LLM instead of training a custom autoencoder.
+3. **Reasoning Capsules**
+   - Store not just facts but causal or conditional statements.
+   - Encourage consistent reasoning patterns when combining capsules.
+
+## 5. Formalizing SIGLA
+1. **Mini-Language Syntax**
+   - `INTENT(text) -> vector`
+   - `RETRIEVE(vector) -> [capsules]`
+   - `MERGE(list) -> capsule-thought`
+   - `INJECT(capsule-thought) -> model`
+2. **Memory Tracking**
+   - Log queries and results to grow a long-term memory store.
+   - Visualize capsule graphs to debug coverage and quality.
+
+## 6. API and Server Implementation
+1. **FastAPI Service**
+   - `/ask`: main entry for questions returning 1Q's final answer.
+   - `/capsule/{id}`: inspect stored capsules.
+2. **Model Connectors**
+   - Run local models using CPU-friendly tools like `llama.cpp` or `ggml`. Avoid renting expensive servers.
+   - Provide optional adapters for external APIs like Claude or GPT-4 only if the budget allows.
+   
+3. **Monitoring and Fallbacks**
+   - Track latency, number of retrieved capsules, and token count.
+   - If retrieval confidence is low, optionally query the model directly or use
+     a simpler RAG step.
+
+## 7. Evaluation and Iteration
+1. **A/B Testing**
+   - Compare 1Q answers with and without SIGLA on sample tasks.
+   - Collect user feedback to refine capsule selection.
+2. **Index Maintenance**
+   - Periodically recompute embeddings and rebuild FAISS indices.
+3. **Security Checks**
+   - Filter sensitive or unwanted content in capsules.
+   - Ensure no personal data from user queries is stored without consent.
+## Reality Check
+- Ensure each step can run on commodity hardware (CPU or single consumer GPU).
+- Keep prompts and capsule storage small to control disk and memory use.
+- Regularly reevaluate whether any feature adds clear value for its cost.
+
+## 8. Final Objective
+- 1Q approaches the depth of a 70B model using SIGLA capsules without requiring costly servers.
+- SIGLA evolves into a modular system that grows memory and reasoning abilities over time.
+
+### Implementation Progress
+- `sigla/core.py` provides an initial FAISS-based capsule store with embedding and search.
+- `sigla/scripts.py` offers CLI commands to ingest capsules and run searches, and can append to an existing index.
+- `sigla/server.py` exposes a FastAPI service for querying and updating the capsule index.
+- `sigla/dsl.py` implements INTENT/RETRIEVE/MERGE/INJECT helpers for prompt construction.
+- Capsules now receive persistent `id`s and an optional `links` field for building a graph.
+- Graph expansion is provided via `sigla.graph.expand_with_links` and the CLI `walk` command.
+- Random walk retrieval is implemented via `sigla.graph.random_walk_links` and selectable in the CLI `walk` command.
+- The DSL exposes `EXPAND` for link-based retrieval.
+- `sigla/log.py` enables optional JSONL query logging for both the CLI and server.
+- `sigla/scripts.py` now includes an interactive `shell` command for quick manual tests.
+- `sigla/scripts.py` can display a capsule by id via the `capsule` command.
+- `sigla/scripts.py` can summarize log files via the `stats` command.
+- Search, inject, walk and shell commands accept `--tags` to filter results by metadata; the server exposes a matching query parameter.
+- `sigla/scripts.py` can show index details via the `info` command.
+- `sigla/scripts.py` can list stored capsules via the `list` command.
+- `sigla/scripts.py` can remove capsules via the `prune` command.
+- `sigla/scripts.py` can summarize retrieved capsules via the `compress` command.
+- `sigla/scripts.py` can rebuild embeddings via the `reindex` command.
+- `sigla/scripts.py` can append capsules via the `update` command; the server
+  exposes `/update` for the same purpose.
+- `sigla/scripts.py` can convert raw text to capsules via the `capsulate` command.
+- Capsules ingested or updated with `--link` automatically connect to nearest neighbors for graph retrieval.
+- Ingestion and reindexing support custom FAISS index factories via `--factory`.
+- `inject` and `shell` commands, as well as the `/ask` endpoint, accept a
+  `temperature` parameter controlling how capsules are merged.
+- The API exposes `/info` and `/list` endpoints mirroring the CLI commands.
+- `/walk` and `/compress` endpoints support graph expansion and summarization.
+- `/prune` and `/reindex` endpoints mirror CLI commands for capsule removal and index rebuilding.
+- `sigla/scripts.py` can export capsules via the `export` command; the server provides a `/dump` endpoint.
+- `CapsuleStore` loads the embedding model lazily so read-only commands start quickly.
+- `sigla/scripts.py` can export capsule links to Graphviz DOT via the `graph` command.
+- The API exposes a `/graph` endpoint returning DOT data for visualization.
+- Capsule ingestion sanitizes obvious personal data like emails and long numeric
+  sequences before storage.
+- `CapsuleStore` exposes `embed_query` and `embed_texts` for direct vectorization; `INTENT` uses these helpers.
+- If `sentence-transformers` isn't installed, `CapsuleStore` falls back to a
+  lightweight hash-based embedder so the CLI works without heavy dependencies.
+- `sigla/scripts.py` can output embeddings via the `embed` command and the server
+  exposes a matching `/embed` endpoint.

--- a/sigla/__init__.py
+++ b/sigla/__init__.py
@@ -1,0 +1,33 @@
+from .core import (
+    CapsuleStore,
+    merge_capsules,
+    compress_capsules,
+    sanitize_text,
+    capsulate_text,
+)
+from .dsl import INTENT, RETRIEVE, MERGE, INJECT, EXPAND
+from .graph import random_walk_links, to_dot
+from .log import start as start_log, log as log_event
+
+try:
+    from .server import app as SiglaApp
+except Exception:  # pragma: no cover - optional dependency
+    SiglaApp = None
+
+__all__ = [
+    "CapsuleStore",
+    "merge_capsules",
+    "compress_capsules",
+    "sanitize_text",
+    "capsulate_text",
+    "SiglaApp",
+    "INTENT",
+    "RETRIEVE",
+    "MERGE",
+    "INJECT",
+    "EXPAND",
+    "random_walk_links",
+    "to_dot",
+    "start_log",
+    "log_event",
+]

--- a/sigla/core.py
+++ b/sigla/core.py
@@ -1,0 +1,356 @@
+import json
+from typing import List, Dict, Any
+import re
+
+try:
+    import faiss  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    faiss = None
+
+try:
+    from sentence_transformers import SentenceTransformer
+except Exception:  # pragma: no cover - optional dependency
+    SentenceTransformer = None
+
+try:
+    from transformers import pipeline
+except Exception:  # pragma: no cover - optional dependency
+    pipeline = None
+
+
+class MissingDependencyError(RuntimeError):
+    """Raised when optional dependencies are not available."""
+    pass
+
+
+# Basic regex to redact obvious personal data such as emails or long digit
+# sequences (phone numbers, IDs). This is a minimal security safeguard to avoid
+# storing sensitive information.
+_PERSONAL_RE = re.compile(r"([\w.+-]+@[\w-]+\.[\w.-]+)|([0-9]{4,})")
+
+
+def sanitize_text(text: str) -> str:
+    """Remove simple personal identifiers from text."""
+    return _PERSONAL_RE.sub("[REDACTED]", text)
+
+
+_SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+class _HashModel:
+    """Fallback embedder using SHA-256 hashing."""
+
+    def __init__(self, dimension: int = 384):
+        self.dimension = dimension
+
+    def encode(self, texts: List[str], convert_to_numpy: bool = True):
+        import hashlib
+        import numpy as np
+
+        vectors = []
+        for text in texts:
+            h = hashlib.sha256(text.encode("utf-8")).digest()
+            arr = np.frombuffer(h, dtype=np.uint8).astype("float32")
+            reps = (self.dimension + len(arr) - 1) // len(arr)
+            vec = np.tile(arr, reps)[: self.dimension]
+            vectors.append(vec)
+        return np.stack(vectors)
+
+    def get_sentence_embedding_dimension(self) -> int:
+        return self.dimension
+
+
+def capsulate_text(text: str, tags: List[str] | None = None, source: str | None = None) -> List[Dict[str, Any]]:
+    """Split raw text into sanitized capsules."""
+    sentences = [s.strip() for s in re.split(_SENTENCE_RE, text) if s.strip()]
+    capsules = []
+    for sent in sentences:
+        capsule: Dict[str, Any] = {"text": sanitize_text(sent)}
+        if tags:
+            capsule["tags"] = list(tags)
+        if source:
+            capsule.setdefault("metadata", {})["source"] = source
+        capsules.append(capsule)
+    return capsules
+
+
+class CapsuleStore:
+    """A lightweight FAISS-backed capsule database."""
+
+    def __init__(
+        self,
+        model_name: str = "sentence-transformers/all-MiniLM-L6-v2",
+        index_factory: str = "Flat",
+        lazy: bool = False,
+    ):
+        if faiss is None:
+            raise MissingDependencyError("faiss package is required")
+
+        self.model_name = model_name
+        self.index_factory = index_factory
+        self.model = None
+        self.dimension = 0
+        self.index = None
+        self.meta: List[Dict[str, Any]] = []
+        # Simple in-memory cache for embeddings to avoid repeated model calls
+        self._cache: Dict[str, Any] = {}
+
+        if not lazy:
+            self._ensure_model()
+            self.index = faiss.index_factory(self.dimension, index_factory, faiss.METRIC_INNER_PRODUCT)
+
+    def _ensure_model(self) -> None:
+        """Load the embedding model if it hasn't been loaded yet."""
+        if self.model is None:
+            if SentenceTransformer is None or self.model_name in {"hash", "none"}:
+                # Fallback to a simple hash-based embedder if transformers are missing
+                # or the user explicitly requests it via ``model_name='hash'``.
+                self.model = _HashModel()
+                self.dimension = self.model.get_sentence_embedding_dimension()
+            else:
+                self.model = SentenceTransformer(self.model_name)
+                self.dimension = self.model.get_sentence_embedding_dimension()
+            if self.index is not None and self.index.d != self.dimension:
+                raise RuntimeError("Index dimension does not match embedding model")
+
+    def embed_texts(self, texts: List[str]):
+        """Return normalized embeddings for a list of texts."""
+        self._ensure_model()
+        try:
+            import numpy as np
+        except Exception:  # pragma: no cover - optional dependency
+            np = None
+
+        if np is None:
+            vectors = self.model.encode(texts, convert_to_numpy=True)
+            faiss.normalize_L2(vectors)
+            return vectors
+
+        missing = []
+        for t in texts:
+            if t not in self._cache:
+                missing.append(t)
+        if missing:
+            new_vectors = self.model.encode(missing, convert_to_numpy=True)
+            for t, v in zip(missing, new_vectors):
+                self._cache[t] = v
+
+        vectors = np.stack([self._cache[t] for t in texts])
+        faiss.normalize_L2(vectors)
+        return vectors
+
+    def embed_query(self, text: str):
+        """Return a single normalized embedding vector."""
+        return self.embed_texts([text])
+
+    def add_capsules(
+        self,
+        capsules: List[Dict[str, Any]],
+        link_neighbors: int = 0,
+        dedup: bool = True,
+    ) -> int:
+        """Embed and add capsules to the index, assigning IDs.
+
+        Parameters
+        ----------
+        capsules:
+            A list of capsule dictionaries with at least a ``text`` field.
+        link_neighbors:
+            If greater than zero, automatically link each new capsule to the
+            nearest existing capsules in the index.
+        """
+        self._ensure_model()
+        start = len(self.meta)
+        existing = {m["text"] for m in self.meta} if dedup else set()
+        cleaned_caps: List[Dict[str, Any]] = []
+        texts: List[str] = []
+        for c in capsules:
+            clean_text = sanitize_text(c["text"])
+            if dedup and clean_text in existing:
+                continue
+            cleaned = c.copy()
+            cleaned["text"] = clean_text
+            cleaned_caps.append(cleaned)
+            texts.append(clean_text)
+            existing.add(clean_text)
+        if not cleaned_caps:
+            return 0
+        vectors = self.embed_texts(texts)
+
+        if not self.index.is_trained:
+            self.index.train(vectors)
+        self.index.add(vectors)
+
+        for i, cap in enumerate(cleaned_caps):
+            meta = cap.copy()
+            meta.setdefault("links", [])
+            meta["id"] = start + i
+            self.meta.append(meta)
+
+        if link_neighbors > 0 and self.index.ntotal > 0:
+            # Search for neighbors including the newly added vectors.
+            _, idxs = self.index.search(vectors, link_neighbors + 1)
+            new_links: Dict[int, List[int]] = {}
+            for i, neighbors in enumerate(idxs):
+                links = []
+                for n in neighbors:
+                    if n == -1 or n == start + i:
+                        continue
+                    links.append(int(n))
+                if links:
+                    meta_links = self.meta[start + i].setdefault("links", [])
+                    for n in links:
+                        if n not in meta_links:
+                            meta_links.append(n)
+                new_links[start + i] = links
+
+            # Symmetrically link neighbors back to the new capsules
+            for new_id, links in new_links.items():
+                for n in links:
+                    if n < 0 or n >= len(self.meta):
+                        continue
+                    rev = self.meta[n].setdefault("links", [])
+                    if new_id not in rev:
+                        rev.append(new_id)
+
+        return len(cleaned_caps)
+
+    def save(self, path: str):
+        faiss.write_index(self.index, path + ".index")
+        with open(path + ".json", "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "model": self.model_name,
+                    "factory": self.index_factory,
+                    "meta": self.meta,
+                },
+                f,
+                ensure_ascii=False,
+                indent=2,
+            )
+
+    def load(self, path: str):
+        self.index = faiss.read_index(path + ".index")
+        with open(path + ".json", "r", encoding="utf-8") as f:
+            data = json.load(f)
+            self.meta = data["meta"]
+            self.model_name = data.get("model", self.model_name)
+            self.index_factory = data.get("factory", "Flat")
+        self.dimension = self.index.d
+        self.model = None
+        self._cache = {}
+
+    def query(self, text: str, top_k: int = 5, tags: List[str] | None = None) -> List[Dict[str, Any]]:
+        """Return top matching capsules, optionally filtering by tags."""
+        self._ensure_model()
+        vector = self.embed_query(text)
+        # oversample to account for tag filtering
+        scores, indices = self.index.search(vector, top_k * 5)
+        results = []
+        for score, idx in zip(scores[0], indices[0]):
+            if idx == -1:
+                continue
+            meta = self.meta[idx]
+            if tags and not set(tags).intersection(meta.get("tags", [])):
+                continue
+            cap = meta.copy()
+            cap["score"] = float(score)
+            cap["id"] = int(idx)
+            results.append(cap)
+            if len(results) >= top_k:
+                break
+        return results
+
+    def remove_capsules(self, ids: List[int]) -> int:
+        """Remove capsules by id, rebuilding the index."""
+        if not ids:
+            return 0
+        self._ensure_model()
+        to_remove = set(ids)
+        mapping: Dict[int, int] = {}
+        new_meta: List[Dict[str, Any]] = []
+        texts: List[str] = []
+        for old_id, meta in enumerate(self.meta):
+            if old_id in to_remove:
+                continue
+            mapping[old_id] = len(new_meta)
+            copy = meta.copy()
+            new_meta.append(copy)
+            texts.append(copy["text"])
+        for meta in new_meta:
+            meta["links"] = [mapping[l] for l in meta.get("links", []) if l in mapping]
+        vectors = self.embed_texts(texts) if texts else None
+        self.index = faiss.IndexFlatIP(self.dimension)
+        if vectors is not None and len(texts) > 0:
+            self.index.add(vectors)
+        for new_id, meta in enumerate(new_meta):
+            meta["id"] = new_id
+        removed = len(self.meta) - len(new_meta)
+        self.meta = new_meta
+        self._cache = {}
+        return removed
+
+    def rebuild_index(self, model_name: str | None = None, index_factory: str | None = None) -> None:
+        """Recompute all embeddings and rebuild the FAISS index."""
+        if model_name:
+            if SentenceTransformer is None:
+                raise MissingDependencyError("sentence-transformers package is required")
+            self.model = SentenceTransformer(model_name)
+            self.model_name = model_name
+            self.dimension = self.model.get_sentence_embedding_dimension()
+        if index_factory:
+            self.index_factory = index_factory
+        self._ensure_model()
+        texts = [m["text"] for m in self.meta]
+        vectors = self.embed_texts(texts) if texts else None
+        self.index = faiss.index_factory(self.dimension, self.index_factory, faiss.METRIC_INNER_PRODUCT)
+        if vectors is not None and len(texts) > 0:
+            self.index.add(vectors)
+        for idx, meta in enumerate(self.meta):
+            meta["id"] = idx
+        self._cache = {}
+
+
+def merge_capsules(capsules: List[Dict[str, Any]], temperature: float = 1.0) -> str:
+    """Merge capsules using a softmax-weighted combination."""
+    if not capsules:
+        return ""
+
+    try:
+        import numpy as np
+    except Exception:  # pragma: no cover - optional dependency
+        np = None
+
+    if np is None:
+        # Fallback to simple ranking if numpy isn't available
+        sorted_caps = sorted(capsules, key=lambda c: c.get("score", 0), reverse=True)
+        texts = [c["text"] for c in sorted_caps]
+        return "\n".join(texts)
+
+    scores = np.array([c.get("score", 0.0) for c in capsules], dtype=float)
+    # Softmax weighting for smoother importance distribution
+    scores = scores / (temperature if temperature else 1.0)
+    scores = scores - scores.max()
+    weights = np.exp(scores)
+    weights /= weights.sum()
+
+    ordering = np.argsort(-weights)
+    texts = [capsules[i]["text"] for i in ordering]
+    return "\n".join(texts)
+
+
+def compress_capsules(capsules: List[Dict[str, Any]], model_name: str = "sshleifer/distilbart-cnn-12-6") -> str:
+    """Summarize a list of capsules into a short snippet."""
+    if not capsules:
+        return ""
+    if pipeline is None:
+        raise MissingDependencyError("transformers package is required for compression")
+
+    try:
+        summarizer = pipeline("summarization", model=model_name)
+    except Exception as e:  # pragma: no cover - optional dependency
+        raise MissingDependencyError(str(e))
+
+    text = "\n".join(c["text"] for c in capsules)
+    summary = summarizer(text, max_length=60, min_length=5, do_sample=False)
+    return summary[0]["summary_text"].strip()

--- a/sigla/dsl.py
+++ b/sigla/dsl.py
@@ -1,0 +1,53 @@
+"""Minimal SIGLA DSL helpers."""
+
+from typing import List
+
+try:
+    import faiss  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    faiss = None
+
+from .core import CapsuleStore, merge_capsules, MissingDependencyError
+from .graph import expand_with_links
+
+
+def INTENT(store: CapsuleStore, text: str):
+    """Embed a query into a vector."""
+    if faiss is None:
+        raise MissingDependencyError("faiss package is required for INTENT")
+    return store.embed_query(text)
+
+
+def RETRIEVE(store: CapsuleStore, vector, top_k: int = 5, tags: List[str] | None = None):
+    """Retrieve top capsules given an embedded query."""
+    if faiss is None:
+        raise MissingDependencyError("faiss package is required for RETRIEVE")
+    scores, indices = store.index.search(vector, top_k * 5)
+    results = []
+    for score, idx in zip(scores[0], indices[0]):
+        if idx == -1:
+            continue
+        meta = store.meta[idx]
+        if tags and not set(tags).intersection(meta.get("tags", [])):
+            continue
+        cap = meta.copy()
+        cap["score"] = float(score)
+        results.append(cap)
+        if len(results) >= top_k:
+            break
+    return results
+
+
+def MERGE(capsules: List[dict]):
+    """Merge several capsules into a single text snippet."""
+    return merge_capsules(capsules)
+
+
+def INJECT(composite: str) -> str:
+    """Return prompt fragment to inject into 1Q."""
+    return f"[Контекст]: \"{composite}\""
+
+
+def EXPAND(capsules: List[dict], store: CapsuleStore, depth: int = 1, limit: int = 10):
+    """Expand capsules via their links."""
+    return expand_with_links(capsules, store, depth=depth, limit=limit)

--- a/sigla/log.py
+++ b/sigla/log.py
@@ -1,0 +1,21 @@
+import json
+import time
+from typing import Optional, Dict, Any
+
+_log_path: Optional[str] = None
+
+def start(path: str) -> None:
+    """Enable logging to the given file."""
+    global _log_path
+    _log_path = path
+
+
+def log(event: Dict[str, Any]) -> None:
+    """Append an event to the log if logging is enabled."""
+    if _log_path is None:
+        return
+    event = event.copy()
+    event["ts"] = time.time()
+    with open(_log_path, "a", encoding="utf-8") as f:
+        json.dump(event, f, ensure_ascii=False)
+        f.write("\n")

--- a/sigla/scripts.py
+++ b/sigla/scripts.py
@@ -1,0 +1,617 @@
+import argparse
+import json
+from pathlib import Path
+
+from .core import (
+    CapsuleStore,
+    merge_capsules,
+    MissingDependencyError,
+    capsulate_text,
+)
+from .dsl import INJECT
+from .graph import expand_with_links
+from . import log as siglog
+
+
+def ingest(
+    json_file: str,
+    index_path: str,
+    model: str,
+    factory: str,
+    link_neighbors: int,
+    tags: list[str] | None = None,
+    source: str | None = None,
+    dedup: bool = True,
+):
+    try:
+        if Path(index_path + ".index").exists():
+            store = CapsuleStore()
+            store.load(index_path)
+        else:
+            store = CapsuleStore(model_name=model, index_factory=factory)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    with open(json_file, "r", encoding="utf-8") as f:
+        capsules = json.load(f)
+    if tags or source:
+        for cap in capsules:
+            if tags:
+                cap_tags = cap.get("tags", [])
+                cap["tags"] = sorted(set(cap_tags).union(tags))
+            if source:
+                cap.setdefault("metadata", {})["source"] = source
+    added = store.add_capsules(capsules, link_neighbors=link_neighbors, dedup=dedup)
+    store.save(index_path)
+    print(f"added {added} capsules")
+    siglog.log({"type": "ingest", "count": added})
+
+
+def update_capsules(
+    json_file: str,
+    index_path: str,
+    link_neighbors: int,
+    tags: list[str] | None = None,
+    source: str | None = None,
+    dedup: bool = True,
+) -> None:
+    """Append capsules to an existing index."""
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    with open(json_file, "r", encoding="utf-8") as f:
+        capsules = json.load(f)
+    if tags or source:
+        for cap in capsules:
+            if tags:
+                cap_tags = cap.get("tags", [])
+                cap["tags"] = sorted(set(cap_tags).union(tags))
+            if source:
+                cap.setdefault("metadata", {})["source"] = source
+    added = store.add_capsules(capsules, link_neighbors=link_neighbors, dedup=dedup)
+    store.save(index_path)
+    print(f"added {added} capsules")
+    siglog.log({"type": "update", "count": added})
+
+
+def capsulate_file(
+    input_file: str,
+    output_file: str,
+    tags: list[str] | None = None,
+    source: str | None = None,
+) -> None:
+    """Convert raw text into capsule JSON.
+
+    ``input_file`` or ``output_file`` can be ``-`` to denote standard
+    input or output.
+    """
+    if input_file == "-":
+        import sys
+
+        text = sys.stdin.read()
+    else:
+        with open(input_file, "r", encoding="utf-8") as f:
+            text = f.read()
+    capsules = capsulate_text(text, tags, source)
+    if output_file == "-":
+        json.dump(capsules, sys.stdout, ensure_ascii=False, indent=2)
+        if not sys.stdout.isatty():
+            sys.stdout.write("\n")
+    else:
+        with open(output_file, "w", encoding="utf-8") as f:
+            json.dump(capsules, f, ensure_ascii=False, indent=2)
+    print(f"wrote {len(capsules)} capsules")
+
+
+def search(index_path: str, query: str, top_k: int, tags: list[str] | None = None):
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    results = store.query(query, top_k=top_k, tags=tags)
+    print(json.dumps(results, ensure_ascii=False, indent=2))
+    siglog.log(
+        {
+            "type": "search",
+            "query": query,
+            "top_k": top_k,
+            "tags": tags,
+            "results": results,
+        }
+    )
+
+
+def inject_snippet(
+    index_path: str,
+    query: str,
+    top_k: int,
+    tags: list[str] | None = None,
+    temperature: float = 1.0,
+) -> None:
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    results = store.query(query, top_k=top_k, tags=tags)
+    snippet = INJECT(merge_capsules(results, temperature=temperature))
+    print(snippet)
+    siglog.log(
+        {
+            "type": "inject",
+            "query": query,
+            "top_k": top_k,
+            "tags": tags,
+            "temperature": temperature,
+        }
+    )
+
+
+def compress_snippet(
+    index_path: str,
+    query: str,
+    top_k: int,
+    tags: list[str] | None = None,
+    model: str = "sshleifer/distilbart-cnn-12-6",
+):
+    """Retrieve capsules and summarize them."""
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    results = store.query(query, top_k=top_k, tags=tags)
+    try:
+        from .core import compress_capsules
+
+        summary = compress_capsules(results, model_name=model)
+        print(summary)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+    siglog.log({"type": "compress", "query": query, "top_k": top_k, "tags": tags})
+
+
+def walk_search(
+    index_path: str,
+    query: str,
+    top_k: int,
+    depth: int,
+    limit: int,
+    tags: list[str] | None = None,
+    algo: str = "bfs",
+    restart: float = 0.5,
+):
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    results = store.query(query, top_k=top_k, tags=tags)
+    if algo == "random":
+        from .graph import random_walk_links
+
+        expanded = random_walk_links(
+            results, store, steps=depth, restart=restart, limit=limit
+        )
+    else:
+        expanded = expand_with_links(results, store, depth=depth, limit=limit)
+    print(json.dumps(expanded, ensure_ascii=False, indent=2))
+    siglog.log(
+        {
+            "type": "walk",
+            "query": query,
+            "top_k": top_k,
+            "depth": depth,
+            "limit": limit,
+            "algo": algo,
+            "restart": restart,
+            "tags": tags,
+        }
+    )
+
+
+def show_capsule(index_path: str, idx: int) -> None:
+    """Print a capsule by its id."""
+    try:
+        store = CapsuleStore(lazy=True)
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    if idx < 0 or idx >= len(store.meta):
+        print("error: invalid id")
+        return
+    print(json.dumps(store.meta[idx], ensure_ascii=False, indent=2))
+
+
+def list_capsules(
+    index_path: str, limit: int = 20, tags: list[str] | None = None
+) -> None:
+    """List capsules optionally filtered by tags."""
+    try:
+        store = CapsuleStore(lazy=True)
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    results = []
+    for meta in store.meta:
+        if tags and not set(tags).intersection(meta.get("tags", [])):
+            continue
+        results.append(meta)
+        if len(results) >= limit:
+            break
+    print(json.dumps(results, ensure_ascii=False, indent=2))
+
+
+def shell(
+    index_path: str,
+    top_k: int,
+    tags: list[str] | None = None,
+    temperature: float = 1.0,
+) -> None:
+    """Run an interactive search loop printing merged context."""
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    print("Enter empty line to exit.")
+    while True:
+        try:
+            query = input("query> ").strip()
+        except EOFError:
+            break
+        if not query:
+            break
+        results = store.query(query, top_k=top_k, tags=tags)
+        snippet = INJECT(merge_capsules(results, temperature=temperature))
+        print(snippet)
+        siglog.log(
+            {
+                "type": "shell",
+                "query": query,
+                "top_k": top_k,
+                "temperature": temperature,
+            }
+        )
+
+
+def show_stats(log_file: str) -> None:
+    """Print simple statistics from a log file."""
+    counts = {}
+    try:
+        with open(log_file, "r", encoding="utf-8") as f:
+            for line in f:
+                event = json.loads(line)
+                etype = event.get("type", "unknown")
+                counts[etype] = counts.get(etype, 0) + 1
+    except FileNotFoundError:
+        print("error: log file not found")
+        return
+    print(json.dumps(counts, ensure_ascii=False, indent=2))
+
+
+def show_info(index_path: str) -> None:
+    """Print summary information about an index."""
+    try:
+        store = CapsuleStore(lazy=True)
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    info = {
+        "model": store.model_name,
+        "dimension": store.dimension,
+        "capsules": len(store.meta),
+    }
+    tag_counts: dict[str, int] = {}
+    for m in store.meta:
+        for t in m.get("tags", []):
+            tag_counts[t] = tag_counts.get(t, 0) + 1
+    if tag_counts:
+        info["tags"] = tag_counts
+    print(json.dumps(info, ensure_ascii=False, indent=2))
+
+
+def export_capsules(
+    index_path: str, output_file: str, tags: list[str] | None = None
+) -> None:
+    """Export capsules to a JSON file."""
+    try:
+        store = CapsuleStore(lazy=True)
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    items = []
+    for meta in store.meta:
+        if tags and not set(tags).intersection(meta.get("tags", [])):
+            continue
+        items.append(meta)
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(items, f, ensure_ascii=False, indent=2)
+    print(f"exported {len(items)} capsules")
+
+
+def export_graph(
+    index_path: str,
+    output_file: str,
+    limit: int | None = None,
+    tags: list[str] | None = None,
+) -> None:
+    """Export capsule links as a Graphviz DOT file."""
+    try:
+        store = CapsuleStore(lazy=True)
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    from .graph import export_dot
+
+    export_dot(store, output_file, limit=limit, tags=tags)
+    print(f"graph written to {output_file}")
+
+
+def prune_capsules(
+    index_path: str, ids: list[int] | None = None, tags: list[str] | None = None
+) -> None:
+    """Remove capsules by id or tags and rebuild the index."""
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    remove_set: set[int] = set(ids or [])
+    if tags:
+        for i, meta in enumerate(store.meta):
+            if set(tags).intersection(meta.get("tags", [])):
+                remove_set.add(i)
+    if not remove_set:
+        print("no matching capsules")
+        return
+    removed = store.remove_capsules(sorted(remove_set))
+    store.save(index_path)
+    siglog.log(
+        {"type": "prune", "removed": removed, "ids": sorted(remove_set), "tags": tags}
+    )
+    print(f"removed {removed} capsules")
+
+
+def reindex_store(
+    index_path: str, model: str | None = None, factory: str | None = None
+) -> None:
+    """Rebuild embeddings for all capsules, optionally with a new model or index type."""
+    try:
+        store = CapsuleStore()
+        store.load(index_path)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    store.rebuild_index(model, factory)
+    store.save(index_path)
+    siglog.log({"type": "reindex", "model": model or store.model_name})
+    print("index rebuilt")
+
+
+def embed_text(text: str, model: str) -> None:
+    """Print the embedding vector for a text."""
+    try:
+        store = CapsuleStore(model_name=model)
+    except MissingDependencyError as e:
+        print(f"error: {e}")
+        return
+    vector = store.embed_query(text)[0].tolist()
+    print(json.dumps(vector))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SIGLA utility")
+    subparsers = parser.add_subparsers(dest="cmd")
+    parser.add_argument("--log-file")
+
+    caps_p = subparsers.add_parser("capsulate", help="split text into capsules")
+    caps_p.add_argument("input_file")
+    caps_p.add_argument("output_file")
+    caps_p.add_argument("--tags")
+    caps_p.add_argument("--source")
+
+    ingest_p = subparsers.add_parser("ingest")
+    ingest_p.add_argument("json_file")
+    ingest_p.add_argument("index_path")
+    ingest_p.add_argument("--model", default="sentence-transformers/all-MiniLM-L6-v2")
+    ingest_p.add_argument("--factory", default="Flat", help="FAISS index factory")
+    ingest_p.add_argument(
+        "--link", type=int, default=0, help="auto-link each new capsule to N neighbors"
+    )
+    ingest_p.add_argument("--tags")
+    ingest_p.add_argument("--source")
+    ingest_p.add_argument(
+        "--no-dedup",
+        action="store_false",
+        dest="dedup",
+        default=True,
+        help="allow duplicate texts",
+    )
+
+    update_p = subparsers.add_parser(
+        "update", help="append capsules to an existing index"
+    )
+    update_p.add_argument("json_file")
+    update_p.add_argument("index_path")
+    update_p.add_argument(
+        "--link", type=int, default=0, help="auto-link each new capsule to N neighbors"
+    )
+    update_p.add_argument("--tags")
+    update_p.add_argument("--source")
+    update_p.add_argument(
+        "--no-dedup",
+        action="store_false",
+        dest="dedup",
+        default=True,
+        help="allow duplicate texts",
+    )
+
+    search_p = subparsers.add_parser("search")
+    search_p.add_argument("index_path")
+    search_p.add_argument("query")
+    search_p.add_argument("--top_k", type=int, default=5)
+    search_p.add_argument("--tags")
+
+    inject_p = subparsers.add_parser("inject")
+    inject_p.add_argument("index_path")
+    inject_p.add_argument("query")
+    inject_p.add_argument("--top_k", type=int, default=5)
+    inject_p.add_argument("--tags")
+    inject_p.add_argument("--temperature", type=float, default=1.0)
+
+    compress_p = subparsers.add_parser("compress", help="summarize retrieved capsules")
+    compress_p.add_argument("index_path")
+    compress_p.add_argument("query")
+    compress_p.add_argument("--top_k", type=int, default=5)
+    compress_p.add_argument("--model", default="sshleifer/distilbart-cnn-12-6")
+    compress_p.add_argument("--tags")
+
+    walk_p = subparsers.add_parser("walk")
+    walk_p.add_argument("index_path")
+    walk_p.add_argument("query")
+    walk_p.add_argument("--top_k", type=int, default=5)
+    walk_p.add_argument("--depth", type=int, default=1)
+    walk_p.add_argument("--limit", type=int, default=10)
+    walk_p.add_argument("--algo", choices=["bfs", "random"], default="bfs")
+    walk_p.add_argument(
+        "--restart", type=float, default=0.5, help="restart prob for random walk"
+    )
+    walk_p.add_argument("--tags")
+
+    cap_p = subparsers.add_parser("capsule")
+    cap_p.add_argument("index_path")
+    cap_p.add_argument("id", type=int)
+
+    list_p = subparsers.add_parser("list", help="list capsules")
+    list_p.add_argument("index_path")
+    list_p.add_argument("--limit", type=int, default=20)
+    list_p.add_argument("--tags")
+
+    export_p = subparsers.add_parser("export", help="dump capsules to JSON")
+    export_p.add_argument("index_path")
+    export_p.add_argument("output_file")
+    export_p.add_argument("--tags")
+
+    graph_p = subparsers.add_parser("graph", help="export graph in DOT format")
+    graph_p.add_argument("index_path")
+    graph_p.add_argument("output_file")
+    graph_p.add_argument("--limit", type=int)
+    graph_p.add_argument("--tags")
+
+    prune_p = subparsers.add_parser("prune", help="remove capsules")
+    prune_p.add_argument("index_path")
+    prune_p.add_argument("--ids")
+    prune_p.add_argument("--tags")
+
+    reindex_p = subparsers.add_parser("reindex", help="rebuild embeddings")
+    reindex_p.add_argument("index_path")
+    reindex_p.add_argument("--model")
+    reindex_p.add_argument("--factory")
+
+    info_p = subparsers.add_parser("info", help="show index summary")
+    info_p.add_argument("index_path")
+
+    embed_p = subparsers.add_parser("embed", help="embed text and print vector")
+    embed_p.add_argument("text")
+    embed_p.add_argument("--model", default="sentence-transformers/all-MiniLM-L6-v2")
+
+    shell_p = subparsers.add_parser("shell")
+    shell_p.add_argument("index_path")
+    shell_p.add_argument("--top_k", type=int, default=5)
+    shell_p.add_argument("--tags")
+    shell_p.add_argument("--temperature", type=float, default=1.0)
+
+    stats_p = subparsers.add_parser("stats", help="summarize a log file")
+    stats_p.add_argument("log_file")
+
+    args = parser.parse_args()
+    if args.log_file and args.cmd != "stats":
+        siglog.start(args.log_file)
+    tags = args.tags.split(",") if hasattr(args, "tags") and args.tags else None
+    if args.cmd == "ingest":
+        ingest(
+            args.json_file,
+            args.index_path,
+            args.model,
+            args.factory,
+            args.link,
+            tags,
+            args.source,
+            args.dedup,
+        )
+    elif args.cmd == "update":
+        update_capsules(
+            args.json_file,
+            args.index_path,
+            args.link,
+            tags,
+            args.source,
+            args.dedup,
+        )
+    elif args.cmd == "capsulate":
+        cap_tags = args.tags.split(",") if args.tags else None
+        capsulate_file(args.input_file, args.output_file, cap_tags, args.source)
+    elif args.cmd == "search":
+        search(args.index_path, args.query, args.top_k, tags)
+    elif args.cmd == "inject":
+        inject_snippet(args.index_path, args.query, args.top_k, tags, args.temperature)
+    elif args.cmd == "compress":
+        compress_snippet(args.index_path, args.query, args.top_k, tags, args.model)
+    elif args.cmd == "walk":
+        walk_search(
+            args.index_path,
+            args.query,
+            args.top_k,
+            args.depth,
+            args.limit,
+            tags,
+            args.algo,
+            args.restart,
+        )
+    elif args.cmd == "shell":
+        shell(args.index_path, args.top_k, tags, args.temperature)
+    elif args.cmd == "capsule":
+        show_capsule(args.index_path, args.id)
+    elif args.cmd == "list":
+        list_tags = args.tags.split(",") if args.tags else None
+        list_capsules(args.index_path, args.limit, list_tags)
+    elif args.cmd == "export":
+        export_tags = args.tags.split(",") if args.tags else None
+        export_capsules(args.index_path, args.output_file, export_tags)
+    elif args.cmd == "graph":
+        graph_tags = args.tags.split(",") if args.tags else None
+        export_graph(args.index_path, args.output_file, args.limit, graph_tags)
+    elif args.cmd == "prune":
+        id_list = [int(x) for x in args.ids.split(",")] if args.ids else None
+        prune_tags = args.tags.split(",") if args.tags else None
+        prune_capsules(args.index_path, id_list, prune_tags)
+    elif args.cmd == "reindex":
+        reindex_store(args.index_path, args.model, args.factory)
+    elif args.cmd == "embed":
+        embed_text(args.text, args.model)
+    elif args.cmd == "info":
+        show_info(args.index_path)
+    elif args.cmd == "stats":
+        show_stats(args.log_file)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/sigla/server.py
+++ b/sigla/server.py
@@ -1,0 +1,259 @@
+try:
+    from fastapi import FastAPI, HTTPException
+except Exception:  # pragma: no cover - optional dependency
+    FastAPI = None
+    class HTTPException(Exception):
+        pass
+
+from typing import List
+import argparse
+import os
+from . import log as siglog
+
+from .core import CapsuleStore, merge_capsules, compress_capsules, MissingDependencyError
+from .graph import expand_with_links, random_walk_links
+
+if FastAPI:
+    app = FastAPI(title="SIGLA Server")
+else:
+    app = None
+
+store: CapsuleStore | None = None
+index_path: str = ""
+
+if app:
+    @app.on_event("startup")
+    def _load_store():
+        global store
+        if not index_path:
+            raise RuntimeError("Index path not set")
+        s = CapsuleStore(lazy=True)
+        if os.path.exists(index_path + ".index"):
+            s.load(index_path)
+        store = s
+
+    @app.get("/search")
+    def search(query: str, top_k: int = 5, tags: str | None = None):
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_list = tags.split(',') if tags else None
+        results = store.query(query, top_k=top_k, tags=tag_list)
+        siglog.log({"type": "search", "query": query, "top_k": top_k, "tags": tag_list, "results": results})
+        return results
+
+    @app.get("/ask")
+    def ask(query: str, top_k: int = 5, tags: str | None = None, temperature: float = 1.0):
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_list = tags.split(',') if tags else None
+        results = store.query(query, top_k=top_k, tags=tag_list)
+        merged = merge_capsules(results, temperature=temperature)
+        siglog.log({"type": "ask", "query": query, "top_k": top_k, "tags": tag_list, "temperature": temperature, "context": merged})
+        return {"context": merged}
+
+    @app.get("/embed")
+    def embed(text: str, model: str = "sentence-transformers/all-MiniLM-L6-v2"):
+        """Return the embedding vector for text."""
+        try:
+            store_local = CapsuleStore(model_name=model)
+        except MissingDependencyError as e:
+            raise HTTPException(status_code=500, detail=str(e))
+        vector = store_local.embed_query(text)[0].tolist()
+        return {"vector": vector}
+
+    @app.get("/capsule/{idx}")
+    def get_capsule(idx: int):
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        if idx < 0 or idx >= len(store.meta):
+            raise HTTPException(status_code=404, detail="Capsule not found")
+        return store.meta[idx]
+
+    @app.post("/update")
+    def update_capsules(capsules: List[dict], link_neighbors: int = 0):
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        store.add_capsules(capsules, link_neighbors=link_neighbors)
+        if index_path:
+            store.save(index_path)
+        siglog.log({"type": "update", "added": len(capsules), "link": link_neighbors})
+        return {"added": len(capsules)}
+
+    @app.get("/info")
+    def info():
+        """Return summary information about the index."""
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_counts: dict[str, int] = {}
+        for m in store.meta:
+            for t in m.get("tags", []):
+                tag_counts[t] = tag_counts.get(t, 0) + 1
+        data = {
+            "model": store.model_name,
+            "dimension": store.dimension,
+            "capsules": len(store.meta),
+        }
+        if tag_counts:
+            data["tags"] = tag_counts
+        return data
+
+    @app.get("/list")
+    def list_capsules(limit: int = 20, tags: str | None = None):
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_list = tags.split(',') if tags else None
+        results = []
+        for meta in store.meta:
+            if tag_list and not set(tag_list).intersection(meta.get("tags", [])):
+                continue
+            results.append(meta)
+            if len(results) >= limit:
+                break
+        return results
+
+    @app.get("/dump")
+    def dump_capsules(limit: int = 0, tags: str | None = None):
+        """Return capsules as JSON (optionally filtered and limited)."""
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_list = tags.split(',') if tags else None
+        results = []
+        for meta in store.meta:
+            if tag_list and not set(tag_list).intersection(meta.get("tags", [])):
+                continue
+            results.append(meta)
+            if limit and len(results) >= limit:
+                break
+        return results
+
+    @app.get("/graph")
+    def graph(limit: int = 0, tags: str | None = None):
+        """Return the capsule graph in Graphviz DOT format."""
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_list = tags.split(',') if tags else None
+        from .graph import to_dot
+        dot = to_dot(store, limit=limit or None, tags=tag_list)
+        return {
+            "dot": dot
+        }
+
+    @app.get("/walk")
+    def walk(
+        query: str,
+        top_k: int = 5,
+        depth: int = 1,
+        limit: int = 10,
+        tags: str | None = None,
+        algo: str = "bfs",
+        restart: float = 0.5,
+    ):
+        """Expand results via capsule links."""
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_list = tags.split(',') if tags else None
+        results = store.query(query, top_k=top_k, tags=tag_list)
+        if algo == "random":
+            expanded = random_walk_links(
+                results, store, steps=depth, restart=restart, limit=limit
+            )
+        else:
+            expanded = expand_with_links(results, store, depth=depth, limit=limit)
+        siglog.log(
+            {
+                "type": "walk",
+                "query": query,
+                "top_k": top_k,
+                "depth": depth,
+                "limit": limit,
+                "algo": algo,
+                "restart": restart,
+                "tags": tag_list,
+            }
+        )
+        return expanded
+
+    @app.get("/compress")
+    def compress(
+        query: str,
+        top_k: int = 5,
+        tags: str | None = None,
+        model: str = "sshleifer/distilbart-cnn-12-6",
+    ):
+        """Return a summary of retrieved capsules."""
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        tag_list = tags.split(',') if tags else None
+        results = store.query(query, top_k=top_k, tags=tag_list)
+        try:
+            summary = compress_capsules(results, model_name=model)
+        except MissingDependencyError as e:
+            raise HTTPException(status_code=500, detail=str(e))
+        siglog.log(
+            {
+                "type": "compress",
+                "query": query,
+                "top_k": top_k,
+                "model": model,
+                "tags": tag_list,
+            }
+        )
+        return {"summary": summary}
+
+    @app.post("/prune")
+    def prune(ids: str = "", tags: str | None = None):
+        """Remove capsules by id or tags and rebuild the index."""
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        id_list = [int(x) for x in ids.split(",") if x] if ids else []
+        tag_list = tags.split(',') if tags else None
+        remove_set = set(id_list)
+        if tag_list:
+            for i, meta in enumerate(store.meta):
+                if set(tag_list).intersection(meta.get("tags", [])):
+                    remove_set.add(i)
+        if not remove_set:
+            return {"removed": 0}
+        removed = store.remove_capsules(sorted(remove_set))
+        if index_path:
+            store.save(index_path)
+        siglog.log({"type": "prune", "removed": removed, "ids": sorted(remove_set), "tags": tag_list})
+        return {"removed": removed}
+
+    @app.post("/reindex")
+    def reindex(model: str | None = None, factory: str | None = None):
+        """Recompute all embeddings and rebuild the index."""
+        if store is None:
+            raise HTTPException(status_code=500, detail="Store not loaded")
+        try:
+            store.rebuild_index(model, factory)
+        except MissingDependencyError as e:
+            raise HTTPException(status_code=500, detail=str(e))
+        if index_path:
+            store.save(index_path)
+        siglog.log({"type": "reindex", "model": model or store.model_name, "factory": factory or store.index_factory})
+        return {"model": store.model_name, "factory": store.index_factory}
+
+def cli():
+    parser = argparse.ArgumentParser(description="Run SIGLA API server")
+    parser.add_argument("index_path", help="Path prefix of the FAISS index")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--log-file")
+    args = parser.parse_args()
+    global index_path
+    index_path = args.index_path
+    if args.log_file:
+        siglog.start(args.log_file)
+
+    if FastAPI is None:
+        parser.error("fastapi is required to run the server")
+    try:
+        import uvicorn  # type: ignore
+    except Exception:
+        parser.error("uvicorn is required to run the server")
+
+    uvicorn.run(app, host=args.host, port=args.port)
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- expose `/embed` endpoint to return a vector for text
- add `embed` CLI command for the same purpose
- document the new options in README and SIGLA_Plan

## Testing
- `python -m sigla.scripts --help`
- `python -m sigla.server --help`
- `pip install faiss-cpu`
- `python -m sigla.scripts ingest tmp_caps.json tmp_index --model hash`
- `python -m sigla.scripts embed "hello" --model hash | head -c 80`


------
https://chatgpt.com/codex/tasks/task_e_6858f2422fc88332b16604743bb733af